### PR TITLE
商品購入機能実装

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
 --require spec_helper
-—format documentation
+—-format documentation

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails', '~> 4.0.0'
   gem 'factory_bot_rails'
+  gem 'faker'
 end
 
 group :development do
@@ -71,3 +72,5 @@ gem 'pry-rails'
 
 gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
+
+gem 'payjp'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,15 +88,22 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faker (2.22.0)
+      i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
@@ -121,6 +128,9 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.0218.1)
     mini_magick (4.12.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.1)
@@ -136,6 +146,7 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.5.8)
     nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
@@ -146,6 +157,8 @@ GEM
     parallel (1.22.1)
     parser (3.2.1.1)
       ast (~> 2.4.1)
+    payjp (0.0.10)
+      rest-client (~> 2.0)
     pg (1.4.6)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -195,6 +208,11 @@ GEM
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.2.5)
     rspec-core (3.12.1)
       rspec-support (~> 3.12.0)
@@ -265,6 +283,9 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (1.2.11)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     unicode-display_width (2.4.2)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -299,11 +320,13 @@ DEPENDENCIES
   capybara (>= 2.15)
   devise
   factory_bot_rails
+  faker
   image_processing (~> 1.2)
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.4.4)
+  payjp
   pg
   pry-rails
   puma (~> 3.11)

--- a/app/assets/stylesheets/orders.scss
+++ b/app/assets/stylesheets/orders.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the order controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,8 +23,10 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    unless current_user == @item.user
-      redirect_to root_path
+    if current_user.id != @item.user.id
+       redirect_to root_path
+    elsif (current_user.id == @item.user.id) && @item.order.present?
+       redirect_to root_path
     end
   end
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,39 @@
+class OrdersController < ApplicationController
+before_action :authenticate_user!, only:[:index]
+before_action :set_order, only:[:index, :create]
+
+  def index
+    @order_delivery = OrderDelivery.new
+    if current_user.id == @order.user.id
+       redirect_to root_path
+    elsif (current_user.id != @order.user.id) && @order.order.present?
+       redirect_to root_path
+    end
+  end
+
+  def create
+    @order_delivery = OrderDelivery.new(order_params)
+    if @order_delivery.valid?
+       Payjp.api_key = "sk_test_4f7dc31f1b927b0c9519a166"
+       Payjp::Charge.create(
+        amount: @order.price,
+        card: order_params[:token],
+        currency: 'jpy'
+      )
+       @order_delivery.save
+       redirect_to root_path
+    else
+      render :index
+    end
+  end
+
+  private
+
+  def set_order
+    @order = Item.find(params[:item_id])
+  end
+
+  def order_params
+    params.require(:order_delivery).permit(:postal_code, :prefecture_id, :municipalities, :address, :building, :phone_number).merge(user_id: current_user.id, item_id: params[:item_id], token: params[:token])
+  end
+end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -33,7 +33,8 @@ before_action :set_order, only:[:index, :create]
   end
 
   def pay_item
-    Payjp.api_key = "sk_test_4f7dc31f1b927b0c9519a166"
+    secreat_key = "sk_test_4f7dc31f1b927b0c9519a166"
+    Payjp.api_key = secreat_key
     Payjp::Charge.create(
     amount: @order.price,
     card: order_params[:token],

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -14,12 +14,7 @@ before_action :set_order, only:[:index, :create]
   def create
     @order_delivery = OrderDelivery.new(order_params)
     if @order_delivery.valid?
-       Payjp.api_key = "sk_test_4f7dc31f1b927b0c9519a166"
-       Payjp::Charge.create(
-        amount: @order.price,
-        card: order_params[:token],
-        currency: 'jpy'
-      )
+       pay_item
        @order_delivery.save
        redirect_to root_path
     else
@@ -35,5 +30,14 @@ before_action :set_order, only:[:index, :create]
 
   def order_params
     params.require(:order_delivery).permit(:postal_code, :prefecture_id, :municipalities, :address, :building, :phone_number).merge(user_id: current_user.id, item_id: params[:item_id], token: params[:token])
+  end
+
+  def pay_item
+    Payjp.api_key = "sk_test_4f7dc31f1b927b0c9519a166"
+    Payjp::Charge.create(
+    amount: @order.price,
+    card: order_params[:token],
+    currency: 'jpy'
+    )
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -33,8 +33,7 @@ before_action :set_order, only:[:index, :create]
   end
 
   def pay_item
-    secreat_key = "sk_test_4f7dc31f1b927b0c9519a166"
-    Payjp.api_key = secreat_key
+    Payjp.api_key = ENV["PAYJP_SECRET_KEY"]
     Payjp::Charge.create(
     amount: @order.price,
     card: order_params[:token],

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -1,0 +1,2 @@
+module OrdersHelper
+end

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -1,6 +1,5 @@
 const pay = () => {
-  const secreatKey = Payjp('pk_test_cc32958a58dbae5df12e8dcf')
-  const payjp = secreatKey
+  const payjp = Payjp(process.env.PAYJP_PUBLIC_KEY);
   const elements = payjp.elements();
   const numberElement = elements.create('cardNumber');
   const expiryElement = elements.create('cardExpiry');

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -1,5 +1,6 @@
 const pay = () => {
-  const payjp = Payjp('pk_test_cc32958a58dbae5df12e8dcf')
+  const secreatKey = Payjp('pk_test_cc32958a58dbae5df12e8dcf')
+  const payjp = secreatKey
   const elements = payjp.elements();
   const numberElement = elements.create('cardNumber');
   const expiryElement = elements.create('cardExpiry');

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -1,0 +1,32 @@
+const pay = () => {
+  const payjp = Payjp('pk_test_cc32958a58dbae5df12e8dcf')
+  const elements = payjp.elements();
+  const numberElement = elements.create('cardNumber');
+  const expiryElement = elements.create('cardExpiry');
+  const cvcElement = elements.create('cardCvc');
+
+  numberElement.mount('#number-form');
+  expiryElement.mount('#expiry-form');
+  cvcElement.mount('#cvc-form');
+
+  const submit = document.getElementById("button");
+
+  submit.addEventListener("click", (e) => {
+    e.preventDefault();
+    payjp.createToken(numberElement).then(function (response) {
+      if (response.error) {
+      } else {
+        const token = response.id;
+        const renderDom = document.getElementById("charge-form");
+        const tokenObj = `<input value=${token} name='token' type="hidden">`;
+        renderDom.insertAdjacentHTML("beforeend", tokenObj);
+      }
+      numberElement.clear();
+      expiryElement.clear();
+      cvcElement.clear();
+      document.getElementById("charge-form").submit();
+    });
+  });
+};
+
+window.addEventListener("load", pay);

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,6 +8,7 @@ require("@rails/ujs").start()
 require("@rails/activestorage").start()
 require("channels")
 require('../new')
+require('../card')
 
 
 // Uncomment to copy all static images under ../images to the output folder and reference

--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -1,0 +1,5 @@
+class Delivery < ApplicationRecord
+
+  has_one :order
+
+end

--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -1,5 +1,5 @@
 class Delivery < ApplicationRecord
 
-  has_one :order
+  belongs_to :order
 
 end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -1,7 +1,0 @@
-class History < ApplicationRecord
-
-  ### Association
-  # has_one :item
-  # belongs_to :user
-
-end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,7 +1,7 @@
 class Item < ApplicationRecord
 
   belongs_to :user
-  # has_one :history
+  has_one :order
   has_one_attached :image
 
   validates :name, { length: { maximum:40 }}

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,7 @@
+class Order < ApplicationRecord   
+
+   has_one :item
+   belongs_to :user
+   has_one :delivery
+
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,6 +1,6 @@
 class Order < ApplicationRecord   
 
-   has_one :item
+   belongs_to :item
    belongs_to :user
    has_one :delivery
 

--- a/app/models/order_delivery.rb
+++ b/app/models/order_delivery.rb
@@ -1,0 +1,18 @@
+class OrderDelivery
+  include ActiveModel::Model
+  attr_accessor :user_id, :item_id, :postal_code, :prefecture_id, :municipalities, :address, :building, :phone_number, :order_id, :token
+
+
+  with_options presence: true do
+    validates :municipalities, :address, :user_id, :item_id, :token
+    validates :postal_code, format: { with: /\A\d{3}-\d{4}\z/, message: "is invalid. Enter it as follows (e.g. 123-4567)" }
+    validates :phone_number, numericality: { only_integer: true, message: "is invalid. Input only number" }, length: { minimum: 10, maximum: 11, message: "is too short" }
+    validates :prefecture_id, numericality: { other_than: 1, message: "can't be blank"}
+  end
+
+  def save
+    order = Order.create(user_id: user_id, item_id: item_id)
+    Delivery.create(postal_code: postal_code, prefecture_id: prefecture_id, municipalities: municipalities, address: address, building: building, phone_number: phone_number, order_id: order.id)
+  end
+
+end

--- a/app/models/order_delivery.rb
+++ b/app/models/order_delivery.rb
@@ -1,6 +1,6 @@
 class OrderDelivery
   include ActiveModel::Model
-  attr_accessor :user_id, :item_id, :postal_code, :prefecture_id, :municipalities, :address, :building, :phone_number, :order_id, :token
+  attr_accessor :user_id, :item_id, :postal_code, :prefecture_id, :municipalities, :address, :building, :phone_number, :token
 
 
   with_options presence: true do

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,5 +12,5 @@ class User < ApplicationRecord
   validates :first_name_kana, :last_name_kana, format: { with: /\A[ァ-ヶー-]+\z/ }
 
   has_many :items
-  # has_many :histories
+  has_many :orders
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -124,13 +124,11 @@
           <div class='item-img-content'>
             <%= image_tag item.image, class: "item-img" if item.image.attached? %>
 
-            <%#if items.history.present? %>
-              <%# 商品が売れていればsold outを表示しましょう %>
-              <%# <div class='sold-out'>
+            <% if item.order.present? %>
+              <div class="sold-out">
                 <span>Sold Out!!</span>
-              </div> %>
-              <%# 商品が売れていればsold outを表示しましょう %>
-            <%# end %>
+              </div>
+            <% end %>
 
           </div>
           <div class='item-info'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,13 +8,11 @@
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
 
-      <%# 商品購入機能時に実装%>
-        <%# 商品が売れている場合は、sold outを表示しましょう %>
-        <%# <div class="sold-out">
+        <% if @item.order.present? %>
+         <div class="sold-out">
           <span>Sold Out!!</span>
-        </div> %>
-        <%# //商品が売れている場合は、sold outを表示しましょう %>
-      <%# end %>
+        </div>
+        <% end %>
 
     </div>
 
@@ -27,14 +25,14 @@
       </span>
     </div>
 
-    <% if user_signed_in? && current_user.id == @item.user.id %>
+    <% if user_signed_in? && (current_user.id == @item.user.id) && @item.order.blank? %>
       <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
       <%= link_to "削除", item_path(@item.id) , method: :delete, class:"item-destroy" %>
     <% end %>
 
-    <% if user_signed_in? && current_user.id != @item.user.id %>
-      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <% if user_signed_in? && (current_user.id != @item.user.id) && @item.order.blank? %>
+      <%= link_to "購入画面に進む", item_orders_path(@item.id) ,class:"item-red-btn"%>
     <% end %>
 
     <div class="item-explain-box">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
   <title>Furima</title>
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
-  <script type="text/javascript" src="https://js.pay.jp/v1/"></script>
+  <script type="text/javascript" src="https://js.pay.jp/v2/pay.js"></script>
   <%= stylesheet_link_tag 'application', media: 'all'%>
   <%= javascript_pack_tag 'application' %>
 </head>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -7,14 +7,14 @@
     </h1>
     <%# 購入内容の表示 %>
     <div class='buy-item-info'>
-      <%= image_tag "item-sample.png", class: 'buy-item-img' %>
+      <%= image_tag @order.image, class: 'buy-item-img' %>
       <div class='buy-item-right-content'>
         <h2 class='buy-item-text'>
-          <%= "商品名" %>
+          <%= @order.name %>
         </h2>
         <div class='buy-item-price'>
-          <p class='item-price-text'>¥<%= '999,999,999' %></p>
-          <p class='item-price-sub-text'><%= '配送料負担' %></p>
+          <p class='item-price-text'>¥<%= @order.price %></p>
+          <p class='item-price-sub-text'><%= @order.load.name %></p>
         </div>
       </div>
     </div>
@@ -26,12 +26,15 @@
         支払金額
       </h1>
       <p class='item-payment-price'>
-        ¥<%= "販売価格" %>
+        ¥<%= @order.price %>
       </p>
     </div>
     <%# /支払額の表示 %>
 
-    <%= form_with id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    <%= form_with model: @order_delivery, url: item_orders_path, method: :post, id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+
+      <%= render 'shared/error_messages', model: f.object %>
+
     <%# カード情報の入力 %>
     <div class='credit-card-form'>
       <h1 class='info-input-haedline'>
@@ -42,7 +45,7 @@
           <label class="form-text">カード情報</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"card-number", placeholder:"カード番号(半角英数字)", maxlength:"16" %>
+        <div id = "number-form" class = "input-default"></div>
         <div class='available-card'>
           <%= image_tag 'card-visa.gif', class: 'card-logo'%>
           <%= image_tag 'card-mastercard.gif', class: 'card-logo'%>
@@ -56,10 +59,7 @@
           <span class="indispensable">必須</span>
         </div>
         <div class='input-expiration-date-wrap'>
-          <%= f.text_area :hoge, class:"input-expiration-date", id:"card-exp-month", placeholder:"例)3" %>
-          <p>月</p>
-          <%= f.text_area :hoge, class:"input-expiration-date", id:"card-exp-year", placeholder:"例)23" %>
-          <p>年</p>
+          <div id = "expiry-form" class = "input-expiration-date"></div>
         </div>
       </div>
       <div class="form-group">
@@ -67,7 +67,7 @@
           <label class="form-text">セキュリティコード</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"card-cvc", placeholder:"カード背面4桁もしくは3桁の番号", maxlength:"4" %>
+        <div id = "cvc-form" class = "input-default"></div>
       </div>
     </div>
     <%# /カード情報の入力 %>
@@ -82,42 +82,42 @@
           <label class="form-text">郵便番号</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
+        <%= f.text_field :postal_code, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">都道府県</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"prefecture"}) %>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">市区町村</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
+        <%= f.text_field :municipalities, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">番地</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
+        <%= f.text_field :address, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">建物名</label>
           <span class="form-any">任意</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
+        <%= f.text_field :building, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">電話番号</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
+        <%= f.text_field :phone_number, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
       </div>
     </div>
     <%# /配送先の入力 %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,4 +45,5 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+  config.active_job.queue_adapter = :inline
 end

--- a/config/initializers/webpacker.rb
+++ b/config/initializers/webpacker.rb
@@ -1,0 +1,1 @@
+Webpacker::Compiler.env["PAYJP_PUBLIC_KEY"] = ENV["PAYJP_PUBLIC_KEY"]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items
+  resources :items do
+    resources :orders
+  end
 end

--- a/db/migrate/20230410072348_create_histories.rb
+++ b/db/migrate/20230410072348_create_histories.rb
@@ -1,9 +1,0 @@
-class CreateHistories < ActiveRecord::Migration[6.0]
-  def change
-    create_table :histories do |t|
-      # t.references :user, null: false, foreign_key: true
-      # t.references :item, null: false, foreign_key: true
-      t.timestamps
-    end
-  end
-end

--- a/db/migrate/20230412035010_create_orders.rb
+++ b/db/migrate/20230412035010_create_orders.rb
@@ -1,0 +1,9 @@
+class CreateOrders < ActiveRecord::Migration[6.0]
+  def change
+    create_table :orders do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :item, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230412064743_create_deliveries.rb
+++ b/db/migrate/20230412064743_create_deliveries.rb
@@ -5,7 +5,7 @@ class CreateDeliveries < ActiveRecord::Migration[6.0]
       t.integer :prefecture_id, null: false
       t.string  :municipalities, null: false
       t.string  :address, null: false
-      t.string  :building, null: false
+      t.string  :building
       t.string  :phone_number, null: false
 
       t.references :order, null: false, foreign_key: true

--- a/db/migrate/20230412064743_create_deliveries.rb
+++ b/db/migrate/20230412064743_create_deliveries.rb
@@ -1,0 +1,15 @@
+class CreateDeliveries < ActiveRecord::Migration[6.0]
+  def change
+    create_table :deliveries do |t|
+      t.string  :postal_code, null: false
+      t.integer :prefecture_id, null: false
+      t.string  :municipalities, null: false
+      t.string  :address, null: false
+      t.string  :building, null: false
+      t.string  :phone_number, null: false
+
+      t.references :order, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_10_072348) do
+ActiveRecord::Schema.define(version: 2023_04_12_064743) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -33,9 +33,17 @@ ActiveRecord::Schema.define(version: 2023_04_10_072348) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "histories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "deliveries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "postal_code", null: false
+    t.integer "prefecture_id", null: false
+    t.string "municipalities", null: false
+    t.string "address", null: false
+    t.string "building", null: false
+    t.string "phone_number", null: false
+    t.bigint "order_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["order_id"], name: "index_deliveries_on_order_id"
   end
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -51,6 +59,15 @@ ActiveRecord::Schema.define(version: 2023_04_10_072348) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_items_on_user_id"
+  end
+
+  create_table "orders", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_orders_on_item_id"
+    t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -72,5 +89,8 @@ ActiveRecord::Schema.define(version: 2023_04_10_072348) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "deliveries", "orders"
   add_foreign_key "items", "users"
+  add_foreign_key "orders", "items"
+  add_foreign_key "orders", "users"
 end

--- a/furima.dio
+++ b/furima.dio
@@ -1,6 +1,6 @@
 <mxfile host="65bd71144e">
     <diagram id="A_DjKKo8lo48KGKveCw2" name="ページ1">
-        <mxGraphModel dx="1308" dy="838" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+        <mxGraphModel dx="545" dy="702" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
             <root>
                 <mxCell id="0"/>
                 <mxCell id="1" parent="0"/>
@@ -58,10 +58,10 @@
                 <mxCell id="35" value="・price" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" parent="13" vertex="1">
                     <mxGeometry y="236" width="280" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="53" value="・user" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" vertex="1" parent="13">
+                <mxCell id="53" value="・user" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" parent="13" vertex="1">
                     <mxGeometry y="266" width="280" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="36" value="Histories" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;align=center;fontSize=14;" parent="1" vertex="1">
+                <mxCell id="36" value="Orders" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;align=center;fontSize=14;" parent="1" vertex="1">
                     <mxGeometry x="80" y="410" width="280" height="86" as="geometry"/>
                 </mxCell>
                 <mxCell id="47" value="" style="fontSize=12;html=1;endArrow=ERmandOne;startArrow=ERmandOne;rounded=0;entryX=0.468;entryY=0.009;entryDx=0;entryDy=0;entryPerimeter=0;" parent="36" target="43" edge="1">
@@ -109,10 +109,10 @@
                 <mxCell id="50" value="・phone_number" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" parent="43" vertex="1">
                     <mxGeometry y="176" width="280" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="51" value="・history" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" parent="43" vertex="1">
+                <mxCell id="51" value="・order" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" parent="43" vertex="1">
                     <mxGeometry y="206" width="280" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="52" value="" style="edgeStyle=entityRelationEdgeStyle;fontSize=12;html=1;endArrow=ERmany;exitX=1;exitY=0.8;exitDx=0;exitDy=0;exitPerimeter=0;" edge="1" parent="1" source="11">
+                <mxCell id="52" value="" style="edgeStyle=entityRelationEdgeStyle;fontSize=12;html=1;endArrow=ERmany;exitX=1;exitY=0.8;exitDx=0;exitDy=0;exitPerimeter=0;" parent="1" source="11" edge="1">
                     <mxGeometry width="100" height="100" relative="1" as="geometry">
                         <mxPoint x="364" y="190" as="sourcePoint"/>
                         <mxPoint x="480" y="189" as="targetPoint"/>

--- a/spec/factories/deliverise.rb
+++ b/spec/factories/deliverise.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :history do
+  factory :delivery do
     
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,13 +1,14 @@
 FactoryBot.define do
   factory :item do
-    name {'hoge'}
-    content {'hoge'}
-    category_id {'2'}
-    situation_id {'2'}
-    load_id {'2'}
-    prefecture_id {'2'}
-    deliveryday_id {'2'}
-    price {'300'}
+    name              {'hoge'}
+    content           {'hoge'}
+    category_id       {'2'}
+    situation_id      {'2'}
+    load_id           {'2'}
+    prefecture_id     {'2'}
+    deliveryday_id    {'2'}
+    price             {'300'}
+
     association :user
 
     after(:build) do |item|

--- a/spec/factories/order_delivery.rb
+++ b/spec/factories/order_delivery.rb
@@ -4,11 +4,9 @@ FactoryBot.define do
     prefecture_id   {'2'}
     municipalities  {'旭市'}
     address         {'1-1-1'}
+    building        {'アジアビル'}
     phone_number    {'12334566789'}
     token           {'tok_abcdefghijk00000000000000000'}
-
-    association :user
-    association :item
     
   end
 end

--- a/spec/factories/order_delivery.rb
+++ b/spec/factories/order_delivery.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :order_delivery do
+    postal_code     {'123-4567'}
+    prefecture_id   {'2'}
+    municipalities  {'旭市'}
+    address         {'1-1-1'}
+    phone_number    {'12334566789'}
+    token           {'tok_abcdefghijk00000000000000000'}
+
+    association :user
+    association :item
+    
+  end
+end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :order do
+    
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,13 +1,15 @@
+require 'faker'
+
 FactoryBot.define do
   factory :user do
-    nickname              { 'hode' }
-    email                 { 'hoge@hoge' }
+    nickname              { 'hoge' }
+    email                 { Faker::Internet.email }
     password              { 'hoge11' }
     password_confirmation { 'hoge11' }
     first_name            { '山田' }
     first_name_kana       { 'ヤマダ' }
     last_name             { '山田' }
-    last_name_kana        { 'タロウ' }
+    last_name_kana        { 'ヤマダ' }
     birthday              { '2000-01-01' }
   end
 end

--- a/spec/models/delivery_spec.rb
+++ b/spec/models/delivery_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Delivery, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/order_delivery_spec.rb
+++ b/spec/models/order_delivery_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe OrderDelivery, type: :model do
       it '電話番号が12桁以上だと購入できない' do
         @order_delivery.phone_number = '090123456789'
         @order_delivery.valid?
-        expect(@order_delivery).to_not be_valid
+        expect(@order_delivery.errors.full_messages).to include("Phone number is too short")
       end
       it '電話番号が半角数値でないと購入できないこと' do
         @order_delivery.phone_number = '0901234567８'

--- a/spec/models/order_delivery_spec.rb
+++ b/spec/models/order_delivery_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe OrderDelivery, type: :model do
+  before do
+    @user = FactoryBot.create(:user)
+    @item = FactoryBot.create(:item)
+    @order_delivery = FactoryBot.build(:order_delivery, user_id: @user.id, item_id: @item.id)
+  end
+
+  describe '商品購入機能' do
+    context '商品が購入できる時' do
+      it 'すべての情報が正しく入力されている場合購入できる' do
+        expect(@order_delivery).to be_valid
+      end
+      it '建物名が空でも購入できる' do
+        @order_delivery.building = nil
+        expect(@order_delivery).to be_valid
+      end
+    end
+
+    context '何処か情報が正しく入力できていない場合購入できない' do
+      it '郵便番号は空では保存できないこと' do
+        @order_delivery.postal_code = nil
+        @order_delivery.valid?
+        expect(@order_delivery.errors.full_messages).to include("Postal code can't be blank")
+      end
+      it '郵便番号は「３桁ハイフン４桁」半角英数字でないと保存できないこと' do
+        @order_delivery.postal_code = '123-456７'
+        @order_delivery.valid?
+        expect(@order_delivery.errors.full_messages).to include("Postal code is invalid. Enter it as follows (e.g. 123-4567)")
+      end
+      it '都道府県idが1で選択されている場合は購入できないこと' do
+        @order_delivery.prefecture_id = '1'
+        @order_delivery.valid?
+        expect(@order_delivery.errors.full_messages).to include("Prefecture can't be blank")
+      end
+      it '市区町村が空だと購入できないこと' do
+        @order_delivery.municipalities = nil
+        @order_delivery.valid?
+        expect(@order_delivery.errors.full_messages).to include("Municipalities can't be blank")
+      end
+      it '番地が空だと購入できないこと' do
+        @order_delivery.address = nil
+        @order_delivery.valid?
+        expect(@order_delivery.errors.full_messages).to include("Address can't be blank")
+      end
+      it '電話番号が空だと購入できないこと' do
+        @order_delivery.phone_number = nil
+        @order_delivery.valid?
+        expect(@order_delivery.errors.full_messages).to include("Phone number can't be blank")
+      end
+      it '電話番号が9桁以下だと購入できないこと' do
+        @order_delivery.phone_number = '123456789'
+        @order_delivery.valid?
+        expect(@order_delivery.errors.full_messages).to include("Phone number is too short")
+      end
+      it '電話番号が12桁以上だと購入できない' do
+        @order_delivery.phone_number = '090123456789'
+        @order_delivery.valid?
+        expect(@order_delivery).to_not be_valid
+      end
+      it '電話番号が半角数値でないと購入できないこと' do
+        @order_delivery.phone_number = '0901234567８'
+        @order_delivery.valid?
+        expect(@order_delivery.errors.full_messages).to include("Phone number is invalid. Input only number")
+      end
+      it 'tokenが空では購入できないこと' do
+        @order_delivery.token = nil
+        @order_delivery.valid?
+        expect(@order_delivery.errors.full_messages).to include("Token can't be blank")
+      end
+
+      it 'user_idが紐づいていなければ購入できないこと' do
+        @order_delivery.user_id = nil
+        @order_delivery.valid?
+        expect(@order_delivery.errors.full_messages).to include("User can't be blank")
+      end
+      it 'item_idが紐づいていなければ購入できないこと' do
+        @order_delivery.item_id = nil
+        @order_delivery.valid?
+        expect(@order_delivery.errors.full_messages).to include("Item can't be blank")
+      end
+
+    end
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe History, type: :model do
+RSpec.describe Order, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"
 end


### PR DESCRIPTION
# What
商品購入機能

# Why
クレジットカードの実装をしたいから。
配送先情報を保存したいから。
購入済みの商品にsold out表記をさせたいから。

# URL
・必要な情報を適切に入力して「購入」ボタンを押すと、商品の購入ができる動画
https://gyazo.com/74e6b9f8068ef2288997dfc4ba042e48
・入力に問題がある状態で「購入」ボタンが押された場合、情報は受け入れられず、購入ページでエラーメッセージが表示される動画
https://gyazo.com/4e549a0d816a81cbb25291c744539fb4
・ログイン状態の場合でも、URLを直接入力して自身が出品していない売却済み商品の商品購入ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/cbfc47956d464acbcae54e4cee0a0bf9
・ログイン状態の場合でも、URLを直接入力して自身が出品した商品の商品購入ページに遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/b83cfcd222d5a3de6fd328d2a0fd3f01
・ログアウト状態の場合は、URLを直接入力して商品購入ページに遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/e2629e7703616f43bcbce4469f6a2d4d
・売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品一覧機能実装時に未実装であった場合）と
売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品詳細機能実装時に未実装であった場合）
https://gyazo.com/87ff1750d18977ee083902ceb42180bc
・ログイン状態の場合でも、売却済みの商品には、「商品の編集」「削除」「購入画面に進む」ボタンが表示されない動画（商品詳細機能実装時に未実装であった場合）
https://gyazo.com/87ff1750d18977ee083902ceb42180bc
・ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（商品情報編集機能実装時に未実装であった場合）
https://gyazo.com/883835af67d79b968d2bebe3dbad5980
テスト結果の画像
<img width="1710" alt="スクリーンショット 2023-04-17 15 06 23" src="https://user-images.githubusercontent.com/127171109/232397794-18b2bea0-65d6-46fe-96a1-4ee093abf196.png">
